### PR TITLE
Functor Bug Fix (Issue #15)

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -190,7 +190,7 @@ function _reorder_part!(acs::ACSet{CD,AD,Ts,Idxed}, ::Val{ob},
         unset_data_index!(acs.indices[attr], junc_attrs[i][attr], i)
     end
   end
-  set_subparts!(acs, 1:last_part, junc_dict)
+  set_subparts!(acs, 1:last_part, (; junc_dict...))
 end
 
 # Copied in from CSetDataStructures in Catlab


### PR DESCRIPTION
This PR updates some outdated syntax in the `functor.jl` file (discussed in Issue #15)

The error was being thrown because `set_subparts!` no longer accepts a dictionary input and requires a `NamedTuple`.