### PR TITLE
Updated AlgPetri compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraicRelations"
 uuid = "1c3ea84b-a956-4dfe-a2f4-485757f48f1d"
 authors = ["bosonbaas <bosonbaas@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 AlgebraicPetri = "4f99eebe-17bf-4e98-b6a1-2c4f205a959b"
@@ -11,7 +11,7 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 LibPQ = "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"
 
 [compat]
-AlgebraicPetri = "0.5.1"
+AlgebraicPetri = "0.6.1"
 AutoHashEquals = "0.2.0"
 Catlab = "^0.9"
 DataFrames = "0.21, 0.22"

--- a/Project.toml
+++ b/Project.toml
@@ -11,9 +11,9 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 LibPQ = "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"
 
 [compat]
-AlgebraicPetri = "0.6.1"
+AlgebraicPetri = "0.6"
 AutoHashEquals = "0.2.0"
-Catlab = "^0.9"
+Catlab = "0.9, 0.10"
 DataFrames = "0.21, 0.22"
 LibPQ = "1.4.0"
 julia = "1.0"


### PR DESCRIPTION
Updating the AlgebraicPetri compatibility version due to [new PR](https://github.com/AlgebraicJulia/AlgebraicPetri.jl/pull/31) for compatibility between AlgebraicPetri and Catlab.