### PR TITLE
Up Version to v0.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraicRelations"
 uuid = "1c3ea84b-a956-4dfe-a2f4-485757f48f1d"
 authors = ["bosonbaas <bosonbaas@gmail.com>"]
-version = "0.2.4"
+version = "0.3.0"
 
 [deps]
 AlgebraicPetri = "4f99eebe-17bf-4e98-b6a1-2c4f205a959b"


### PR DESCRIPTION
This PR provides the version increment. This version adds support for Catlab v0.13, specifically for the new struct acset structures. This includes a small modification of the API for defining schemas, using macros instead of functions.